### PR TITLE
Fixes pillow version mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Note that JPEG decoding can be a bottleneck, particularly if you have a fast GPU
 
 ```bash
 conda uninstall --force jpeg libtiff -y
-conda install -c conda-forge libjpeg-turbo
+conda install -c conda-forge libjpeg-turbo pillow==6.0.0
 CC="cc -mavx2" pip install --no-cache-dir -U --force-reinstall --no-binary :all: --compile pillow-simd
 ```
 If you only care about faster JPEG decompression, it can be `pillow` or `pillow-simd` in the last command above, the latter speeds up other image processing operations. For the full story see [Pillow-SIMD](https://docs.fast.ai/performance.html#faster-image-processing).


### PR DESCRIPTION
Directly following the instructions on README causes the error:
```
from fastai.vision import *
ImportError: The _imaging extension was built for another version of Pillow or PIL:
Core version: 6.0.0.post0
Pillow version: 6.2.0
```

In the proposed changes I just specify pillow version to be 6.0.0
